### PR TITLE
fix showing the required ember-cli npm version

### DIFF
--- a/lib/ember-cli/app.rb
+++ b/lib/ember-cli/app.rb
@@ -108,7 +108,7 @@ module EmberCLI
       unless match_version?(version, EMBER_CLI_VERSION)
         fail <<-MSG.strip_heredoc
           EmberCLI Rails require ember-cli NPM package version to be
-          #{requirement} to work properly. From within your EmberCLI directory
+          #{EMBER_CLI_VERSION} to work properly. From within your EmberCLI directory
           please update your package.json accordingly and run:
 
             $ npm install


### PR DESCRIPTION
with the incorrect version installed, an undefined error is thrown:

```
NameError (undefined local variable or method `requirement' for #<EmberCLI::App:0x007feaf89b0df8>):
  ember-cli-rails (0.0.14) lib/ember-cli/app.rb:111:in `check_ember_cli_version!'
  ...
```