### PR TITLE
use local ember executable as fallback

### DIFF
--- a/lib/ember-cli/app.rb
+++ b/lib/ember-cli/app.rb
@@ -68,9 +68,19 @@ module EmberCLI
       MSG
     end
 
+    def ember_path
+      @ember_path ||= begin
+        local_path = app_path.join('node_modules', '.bin', 'ember')
+        if File.exist?(local_path) && File.executable?(local_path)
+          local_path
+        else
+          fail "No local ember executable found. You should run `npm install` inside the #{@app} app located at #{app_path}"
+        end
+      end
+    end
+
     private
 
-    delegate :ember_path, to: :configuration
     delegate :match_version?, :non_production?, to: Helpers
     delegate :tee_path, to: :configuration
     delegate :configuration, to: :EmberCLI

--- a/lib/ember-cli/app.rb
+++ b/lib/ember-cli/app.rb
@@ -15,7 +15,9 @@ module EmberCLI
     def compile
       prepare
       silence_stream STDOUT do
-        system(env_hash, command, chdir: app_path, err: :out)
+        Dir.chdir app_path do
+          system(env_hash, command, err: :out)
+        end
       end
     end
 

--- a/lib/ember-cli/configuration.rb
+++ b/lib/ember-cli/configuration.rb
@@ -17,16 +17,10 @@ module EmberCLI
       @tee_path = Helpers.which("tee")
     end
 
-    def ember_path
-      @ember_path ||= Helpers.which("ember").tap do |path|
-        fail "ember-cli executable could not be found" unless path
-      end
-    end
-
     def build_timeout
       @build_timeout ||= 5
     end
 
-    attr_writer :ember_path, :build_timeout
+    attr_writer :build_timeout
   end
 end


### PR DESCRIPTION
uses the local ember executable in node_modules/.bin
in one of the apps if it is available. This is useful
for production environments where you cannot install
packages globally into the PATH with npm install -g.