### PR TITLE
Add :appname/ to the precompile list instead of */:appname/. refs #51.

### DIFF
--- a/lib/ember-cli/app.rb
+++ b/lib/ember-cli/app.rb
@@ -139,7 +139,7 @@ module EmberCLI
     end
 
     def add_assets_to_precompile_list
-      Rails.configuration.assets.precompile << /(?:\/|\A)#{name}\//
+      Rails.configuration.assets.precompile << /\A#{name}\//
     end
 
     def command(options={})


### PR DESCRIPTION
As discussed with @rwz in #51, this commit no longer causes subfolders with the same name as an app to be compiled.