### PR TITLE
Broccoli fingerprints

### DIFF
--- a/lib/ember-cli/app.rb
+++ b/lib/ember-cli/app.rb
@@ -76,6 +76,19 @@ module EmberCLI
       end
     end
 
+    def dist_path
+      @dist_path ||= EmberCLI.root.join("apps", name).tap(&:mkpath)
+    end
+
+    def assets_path
+      @assets_path ||= EmberCLI.root.join("assets").tap(&:mkpath)
+    end
+
+    def ember_app_name
+      @ember_app_name ||= options.fetch(:name){ package_json.fetch(:name) }
+    end
+
+
     private
 
     delegate :match_version?, :non_production?, to: Helpers
@@ -158,9 +171,6 @@ module EmberCLI
       "| #{tee_path} -a #{log_path}" if tee_path
     end
 
-    def ember_app_name
-      @ember_app_name ||= options.fetch(:name){ package_json.fetch(:name) }
-    end
 
     def app_path
       @app_path ||= begin
@@ -181,13 +191,7 @@ module EmberCLI
       Rails.root.join("log", "ember-#{name}.#{Rails.env}.log")
     end
 
-    def dist_path
-      @dist_path ||= EmberCLI.root.join("apps", name).tap(&:mkpath)
-    end
 
-    def assets_path
-      @assets_path ||= EmberCLI.root.join("assets").tap(&:mkpath)
-    end
 
     def environment
       non_production?? "development" : "production"
@@ -208,8 +212,8 @@ module EmberCLI
 
     def env_hash
       ENV.clone.tap do |vars|
-        vars.store "DISABLE_FINGERPRINTING", "true"
-        vars.store "SUPPRESS_JQUERY", "true" if suppress_jquery?
+        # vars.store "DISABLE_FINGERPRINTING", "true"
+        # vars.store "SUPPRESS_JQUERY", "true" if suppress_jquery?
       end
     end
 

--- a/lib/ember-cli/app.rb
+++ b/lib/ember-cli/app.rb
@@ -15,17 +15,22 @@ module EmberCLI
     def compile
       prepare
       silence_stream(STDOUT){ exec command }
+      copy_ember_assets_to_rails
+      add_fingerprinted_ember_assets_to_manifest unless Helpers.non_production?
     end
 
     def run
       prepare
-      cmd = command(watch: true)
-      @pid = exec(cmd, method: :spawn)
+      # cmd = command(watch: true)
+      # @pid = exec(cmd, method: :spawn)
+      @pid = exec command
+      copy_ember_assets_to_rails
+      add_fingerprinted_ember_assets_to_manifest unless Helpers.non_production?
       at_exit{ stop }
     end
 
     def stop
-      Process.kill "INT", pid if pid
+      Process.kill "INT", pid if pid && pid.is_a?(Integer)
       @pid = nil
     end
 
@@ -75,19 +80,6 @@ module EmberCLI
         MSG
       end
     end
-
-    def dist_path
-      @dist_path ||= EmberCLI.root.join("apps", name).tap(&:mkpath)
-    end
-
-    def assets_path
-      @assets_path ||= EmberCLI.root.join("assets").tap(&:mkpath)
-    end
-
-    def ember_app_name
-      @ember_app_name ||= options.fetch(:name){ package_json.fetch(:name) }
-    end
-
 
     private
 
@@ -167,10 +159,58 @@ module EmberCLI
       "#{ember_path} build #{watch} --environment #{environment} --output-path #{dist_path} #{log_pipe}"
     end
 
+    def copy_ember_assets_to_rails
+
+      ember_assets_path = [EmberCLI.root, 'apps', name, 'assets', '.'].join('/')
+      ember_fonts_path = [EmberCLI.root, 'apps', name, 'fonts'].join('/')
+      rails_assets_path = [Rails.root, 'public', 'assets'].join('/')
+      rails_fonts_path = [Rails.root, 'public'].join('/')
+
+      puts "Copying Ember dist/assets into rails public/assets..."
+      puts "#{ember_assets_path} \n--> #{rails_assets_path}"
+      FileUtils.cp_r(ember_assets_path, rails_assets_path)
+
+      if File.directory?(ember_fonts_path)
+        puts "Copying Ember dist/fonts into rails public/fonts..."
+        puts "#{ember_fonts_path} \n--> #{rails_fonts_path}"
+        FileUtils.cp_r(ember_fonts_path, rails_fonts_path)
+      end
+    end
+
+    def add_fingerprinted_ember_assets_to_manifest
+      rails_assets_path = [Rails.root, 'public', 'assets'].join('/')
+
+      fingerprints = {}
+      Dir["#{rails_assets_path}/*"].map{|path| File.basename(path)}.each do |fn|
+        fingerprints[:app_js] = fn if fn.index("#{ember_app_name}-") == 0 && File.extname(fn) == '.js'
+        fingerprints[:app_css] = fn if fn.index("#{ember_app_name}-") == 0 && File.extname(fn) == '.css'
+        fingerprints[:vendor_js] = fn if fn.index("vendor-") == 0 && File.extname(fn) == '.js'
+        fingerprints[:vendor_css] = fn if fn.index("vendor-") == 0 && File.extname(fn) == '.css'
+        fingerprints[:manifest_json] = fn if fn.index("manifest-") == 0 && File.extname(fn) == '.json'
+      end
+      fingerprints[:manifest_json_path] = [rails_assets_path, fingerprints[:manifest_json]].join('/')
+      manifest = JSON.parse(File.open(fingerprints[:manifest_json_path]).read)
+
+      manifest['assets']["#{name}/#{ember_app_name}.js"] = fingerprints[:app_js]
+      manifest['assets']["#{name}/#{ember_app_name}.css"] = fingerprints[:app_css]
+      manifest['assets']["#{name}/vendor.js"] = fingerprints[:vendor_js]
+      manifest['assets']["#{name}/vendor.css"] = fingerprints[:vendor_css]
+
+      puts "Updating manifest.json with fingerprints:"
+      puts "#{fingerprints.to_json}"
+
+      File.open(fingerprints[:manifest_json_path],"w") do |f|
+        f.write(manifest.to_json)
+      end
+    end
+
     def log_pipe
       "| #{tee_path} -a #{log_path}" if tee_path
     end
 
+    def ember_app_name
+      @ember_app_name ||= options.fetch(:name){ package_json.fetch(:name) }
+    end
 
     def app_path
       @app_path ||= begin
@@ -191,7 +231,13 @@ module EmberCLI
       Rails.root.join("log", "ember-#{name}.#{Rails.env}.log")
     end
 
+    def dist_path
+      @dist_path ||= EmberCLI.root.join("apps", name).tap(&:mkpath)
+    end
 
+    def assets_path
+      @assets_path ||= EmberCLI.root.join("assets").tap(&:mkpath)
+    end
 
     def environment
       non_production?? "development" : "production"

--- a/lib/ember-cli/helpers.rb
+++ b/lib/ember-cli/helpers.rb
@@ -29,8 +29,47 @@ module EmberCLI
       Rake.application.instance_eval do
         @tasks["assets:precompile:original"] = @tasks.delete("assets:precompile")
         Rake::Task.define_task "assets:precompile", [:assets, :precompile] => :environment do
-          EmberCLI.compile!
+          Rake::Task["assets:clobber"].execute
           Rake::Task["assets:precompile:original"].execute
+          EmberCLI.compile!
+
+          EmberCLI.configuration.apps.each do |name, app|
+            ember_assets_path = [EmberCLI.root, 'apps', name, 'assets', '.'].join('/')
+            ember_fonts_path = [EmberCLI.root, 'apps', name, 'fonts'].join('/')
+            rails_assets_path = [Rails.root, 'public', 'assets'].join('/')
+            FileUtils.cp_r(ember_assets_path, rails_assets_path)
+            FileUtils.cp_r(ember_fonts_path, rails_assets_path)
+
+            fingerprinted_app_js = nil
+            fingerprinted_app_css = nil
+            fingerprinted_vendor_js = nil
+            fingerprinted_vendor_css = nil
+            fingerprinted_manifest_json = nil
+
+            Dir["#{rails_assets_path}/*"].each do |fn|
+              fn = File.basename(fn)
+              fingerprinted_app_js = fn if fn.index("#{app.ember_app_name}-") == 0 && File.extname(fn) == '.js'
+              fingerprinted_app_css = fn if fn.index("#{app.ember_app_name}-") == 0 && File.extname(fn) == '.css'
+              fingerprinted_vendor_js = fn if fn.index("vendor-") == 0 && File.extname(fn) == '.js'
+              fingerprinted_vendor_css = fn if fn.index("vendor-") == 0 && File.extname(fn) == '.css'
+              fingerprinted_manifest_json = fn if fn.index("manifest-") == 0 && File.extname(fn) == '.json'
+            end
+            fingerprinted_manifest_json_path = [rails_assets_path, fingerprinted_manifest_json].join('/')
+            manifest = JSON.parse(File.open(fingerprinted_manifest_json_path).read)
+
+            manifest['assets']["#{name}/#{app.ember_app_name}.js"] = fingerprinted_app_js
+            manifest['assets']["#{name}/#{app.ember_app_name}.css"] = fingerprinted_app_css
+            manifest['assets']["#{name}/vendor.js"] = fingerprinted_vendor_js
+            manifest['assets']["#{name}/vendor.css"] = fingerprinted_vendor_css
+
+            File.open(fingerprinted_manifest_json_path,"w") do |f|
+              f.write(manifest.to_json)
+            end
+
+          end
+
+
+
         end
       end
     end

--- a/lib/ember-cli/helpers.rb
+++ b/lib/ember-cli/helpers.rb
@@ -38,7 +38,7 @@ module EmberCLI
             ember_fonts_path = [EmberCLI.root, 'apps', name, 'fonts'].join('/')
             rails_assets_path = [Rails.root, 'public', 'assets'].join('/')
             FileUtils.cp_r(ember_assets_path, rails_assets_path)
-            FileUtils.cp_r(ember_fonts_path, rails_assets_path)
+            FileUtils.cp_r(ember_fonts_path, [Rails.root, 'public'].join('/'))
 
             fingerprinted_app_js = nil
             fingerprinted_app_css = nil

--- a/lib/ember-cli/helpers.rb
+++ b/lib/ember-cli/helpers.rb
@@ -32,44 +32,6 @@ module EmberCLI
           Rake::Task["assets:clobber"].execute
           Rake::Task["assets:precompile:original"].execute
           EmberCLI.compile!
-
-          EmberCLI.configuration.apps.each do |name, app|
-            ember_assets_path = [EmberCLI.root, 'apps', name, 'assets', '.'].join('/')
-            ember_fonts_path = [EmberCLI.root, 'apps', name, 'fonts'].join('/')
-            rails_assets_path = [Rails.root, 'public', 'assets'].join('/')
-            FileUtils.cp_r(ember_assets_path, rails_assets_path)
-            FileUtils.cp_r(ember_fonts_path, [Rails.root, 'public'].join('/'))
-
-            fingerprinted_app_js = nil
-            fingerprinted_app_css = nil
-            fingerprinted_vendor_js = nil
-            fingerprinted_vendor_css = nil
-            fingerprinted_manifest_json = nil
-
-            Dir["#{rails_assets_path}/*"].each do |fn|
-              fn = File.basename(fn)
-              fingerprinted_app_js = fn if fn.index("#{app.ember_app_name}-") == 0 && File.extname(fn) == '.js'
-              fingerprinted_app_css = fn if fn.index("#{app.ember_app_name}-") == 0 && File.extname(fn) == '.css'
-              fingerprinted_vendor_js = fn if fn.index("vendor-") == 0 && File.extname(fn) == '.js'
-              fingerprinted_vendor_css = fn if fn.index("vendor-") == 0 && File.extname(fn) == '.css'
-              fingerprinted_manifest_json = fn if fn.index("manifest-") == 0 && File.extname(fn) == '.json'
-            end
-            fingerprinted_manifest_json_path = [rails_assets_path, fingerprinted_manifest_json].join('/')
-            manifest = JSON.parse(File.open(fingerprinted_manifest_json_path).read)
-
-            manifest['assets']["#{name}/#{app.ember_app_name}.js"] = fingerprinted_app_js
-            manifest['assets']["#{name}/#{app.ember_app_name}.css"] = fingerprinted_app_css
-            manifest['assets']["#{name}/vendor.js"] = fingerprinted_vendor_js
-            manifest['assets']["#{name}/vendor.css"] = fingerprinted_vendor_css
-
-            File.open(fingerprinted_manifest_json_path,"w") do |f|
-              f.write(manifest.to_json)
-            end
-
-          end
-
-
-
         end
       end
     end


### PR DESCRIPTION
For those looking to use the broccoli/ember fingerprinting and asset pipeline, I've created the following branch that may be helpful to others.  The basic idea here is that after ember compiles, we copy everything over to the rails assets folder.  

When done in production mode, it works as follows:
1. Compile and fingerprint rails assets w/o any ember assets
2. Compile and fingerprint ember assets outside of rails
3. Copy the compiled ember assets into the rails asset directory (public/assets)
4. Update rail's manifest.json to reference ember's app_name.js, app_name.css, vendor.js and vendor.css.

This might be helpful for this issue:  https://github.com/rwz/ember-cli-rails/issues/30

I'd be happy to hear other people's thoughts.

Side note: I also disabled the `SUPPRESS_JQUERY` flag, which seemed to help our app.