### PR TITLE
Expose a rake task to `npm install`

### DIFF
--- a/lib/ember-cli-rails.rb
+++ b/lib/ember-cli-rails.rb
@@ -33,6 +33,11 @@ module EmberCLI
     end
   end
 
+  def install_dependencies!
+    prepare!
+    each_app &:install_dependencies
+  end
+
   def run!
     prepare!
     each_app &:run

--- a/lib/ember-cli/app.rb
+++ b/lib/ember-cli/app.rb
@@ -17,7 +17,7 @@ module EmberCLI
     end
 
     def install_dependencies
-      exec "npm install"
+      exec "#{npm_path} install"
     end
 
     def run
@@ -82,7 +82,7 @@ module EmberCLI
     private
 
     delegate :match_version?, :non_production?, to: Helpers
-    delegate :tee_path, to: :configuration
+    delegate :tee_path, :npm_path, to: :configuration
     delegate :configuration, to: :EmberCLI
 
     def build_timeout

--- a/lib/ember-cli/app.rb
+++ b/lib/ember-cli/app.rb
@@ -16,6 +16,10 @@ module EmberCLI
       silence_stream(STDOUT){ exec command }
     end
 
+    def install_dependencies
+      exec "npm install"
+    end
+
     def run
       prepare
       cmd = command(watch: true)

--- a/lib/ember-cli/configuration.rb
+++ b/lib/ember-cli/configuration.rb
@@ -17,6 +17,10 @@ module EmberCLI
       @tee_path = Helpers.which("tee")
     end
 
+    def npm_path
+      @npm_path ||= Helpers.which("npm")
+    end
+
     def build_timeout
       @build_timeout ||= 5
     end

--- a/lib/ember-cli/helpers.rb
+++ b/lib/ember-cli/helpers.rb
@@ -25,14 +25,6 @@ module EmberCLI
       !Rails.env.production? && Rails.configuration.consider_all_requests_local
     end
 
-    def inject_install_dependencies_task!
-      Rake.application.instance_eval do
-        Rake::Task.define_task "ember-cli:install_dependencies" => :environment do
-          EmberCLI.install_dependencies!
-        end
-      end
-    end
-
     def override_assets_precompile_task!
       Rake.application.instance_eval do
         @tasks["assets:precompile:original"] = @tasks.delete("assets:precompile")

--- a/lib/ember-cli/helpers.rb
+++ b/lib/ember-cli/helpers.rb
@@ -25,10 +25,18 @@ module EmberCLI
       !Rails.env.production? && Rails.configuration.consider_all_requests_local
     end
 
+    def inject_install_dependencies_task!
+      Rake.application.instance_eval do
+        Rake::Task.define_task "ember-cli:install_dependencies" => :environment do
+          EmberCLI.install_dependencies!
+        end
+      end
+    end
+
     def override_assets_precompile_task!
       Rake.application.instance_eval do
         @tasks["assets:precompile:original"] = @tasks.delete("assets:precompile")
-        Rake::Task.define_task "assets:precompile", [:assets, :precompile] => :environment do
+        Rake::Task.define_task "assets:precompile", [:assets, :precompile] => "ember-cli:install_dependencies" do
           EmberCLI.compile!
           Rake::Task["assets:precompile:original"].execute
         end

--- a/lib/ember-cli/railtie.rb
+++ b/lib/ember-cli/railtie.rb
@@ -17,6 +17,7 @@ module EmberCLI
     rake_tasks do
       require "sprockets/rails/task"
       Helpers.override_assets_precompile_task!
+      Helpers.inject_install_dependencies_task!
     end
   end
 end

--- a/lib/ember-cli/railtie.rb
+++ b/lib/ember-cli/railtie.rb
@@ -16,8 +16,8 @@ module EmberCLI
 
     rake_tasks do
       require "sprockets/rails/task"
+      load "tasks/ember-cli.rake"
       Helpers.override_assets_precompile_task!
-      Helpers.inject_install_dependencies_task!
     end
   end
 end

--- a/lib/tasks/ember-cli.rake
+++ b/lib/tasks/ember-cli.rake
@@ -1,0 +1,6 @@
+namespace "ember-cli" do
+  desc "Installs each EmberCLI app's dependencies"
+  task install_dependencies: :environment do
+    EmberCLI.install_dependencies!
+  end
+end


### PR DESCRIPTION
Assumes either:
* `bower` is a globally accessible command
* `package.json` includes:
```json
"tasks": {
  "postinstall": "/path/to/bower/bin/bower install"
}
```

Corresponds to https://github.com/rwz/ember-cli-rails/issues/33