### PR TITLE
Raise error when app timeout to compile

### DIFF
--- a/lib/ember-cli/app.rb
+++ b/lib/ember-cli/app.rb
@@ -68,6 +68,8 @@ module EmberCLI
 
         ============================= WARNING! =============================
       MSG
+
+      raise "Seems like Ember #{name} application takes more than #{build_timeout} seconds to compile. Please check the logs."
     end
 
     def ember_path


### PR DESCRIPTION
Why? It's really annoying to wait for the app to load and never load, so after a while I realize that I need to go to the terminal and check if the ember app have been compiled. Plus, if you have Travis CI or anything else running your tests and you have an error in your ember app, your tests might not get it because nothing raises.