### PR TITLE
Use non_production? helper in middleware

### DIFF
--- a/lib/ember-cli/middleware.rb
+++ b/lib/ember-cli/middleware.rb
@@ -15,7 +15,7 @@ module EmberCLI
 
     def enable_ember_cli
       @enabled ||= begin
-        if Rails.env.development?
+        if Helpers.non_production?
           EmberCLI.run!
         else
           EmberCLI.compile!


### PR DESCRIPTION
The `Helpers.non_production?` method correctly handles cases where local development is happening outside of a Rails environment called `development`. It seems to make sense to use it in the middleware code, no?