### PR TITLE
Change livereload path in README to <ember-cli-path>/app

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,14 +123,15 @@ init` and then add the following to your `Guardfile`.
 ```ruby
 guard "livereload" do
   # ...
-  watch %r{app/<your-appname>/\w+/.+\.(js|hbs|html|css|<other-extensions>)}
+  watch %r{app/<your-appname>/app/\w+/.+\.(js|hbs|html|css|<other-extensions>)}
   # ...
 end
 ```
 
 This tells Guard to watch your EmberCLI app for any changes to the JavaScript,
-Handlebars, HTML, or CSS files. Take note that other extensions can be added to
-the line (such as `coffee` for CoffeeScript) to watch them for changes as well.
+Handlebars, HTML, or CSS files within `app` path. Take note that other
+extensions can be added to the line (such as `coffee` for CoffeeScript) to
+watch them for changes as well.
 
 ## Additional Information
 


### PR DESCRIPTION
Current watch expression includes `~/tmp` and `~/dist` paths. As files in those two folders also get modified after recompilation, additional unnecessary reloads are triggered.

Changing watch path to `<ember-cli-path>/app` still reloads for the majority of relevant changes; however some changes will not trigger reload (e.g. `Brocfile.js`, etc), but as I recall changes in these files also don't trigger reload when running standalone EmberCLI.

Alternatively, one could exclude `~/tmp` and `~/dist` paths explicitly, however I think it is not worth the trouble...