### PR TITLE
Expose `EmberCLI.compile!` to as Rake task

### DIFF
--- a/lib/tasks/ember-cli.rake
+++ b/lib/tasks/ember-cli.rake
@@ -1,4 +1,9 @@
 namespace "ember-cli" do
+  desc "Runs `ember build` for each App"
+  task compile: :environment do
+    EmberCLI.compile!
+  end
+
   desc "Runs `ember test` for each App"
   task test: :environment do
     EmberCLI.run_tests!


### PR DESCRIPTION
Setting up a rake hook for `ember-cli:compile` ensures that `rake spec` 
executes with the apps already compiled.

```ruby
task spec: ["ember-cli:compile"]
```

This prevents timeouts for waiting to compile the apps on the first request.