### PR TITLE
support for non-idempotent paths

### DIFF
--- a/lib/ember-cli/app.rb
+++ b/lib/ember-cli/app.rb
@@ -80,12 +80,7 @@ module EmberCLI
     end
 
     def ember_path
-      @ember_path ||= app_path.join("node_modules", ".bin", "ember").tap do |path|
-        fail <<-MSG.strip_heredoc unless path.executable?
-          No local ember executable found. You should run `npm install`
-          inside the #{name} app located at #{app_path}
-        MSG
-      end
+      @ember_path ||= Pathname.new("node_modules/.bin/ember")
     end
 
     private

--- a/lib/ember-cli/app.rb
+++ b/lib/ember-cli/app.rb
@@ -80,7 +80,13 @@ module EmberCLI
     end
 
     def ember_path
-      @ember_path ||= Pathname.new("node_modules/.bin/ember")
+      relative_ember_executable_path = 'node_modules/.bin/ember'
+      @ember_path ||= Pathname.new('').join(relative_ember_executable_path).tap do |path|
+        fail <<-MSG.strip_heredoc unless app_path.join(relative_ember_executable_path).executable?
+          No local ember executable found. You should run `npm install`
+          inside the #{name} app located at #{app_path}
+        MSG
+      end
     end
 
     private


### PR DESCRIPTION
### The problem

When customizing the path in ember.rb, a non-idempotent path (something other than ../app_name) would result in the build never occuring.  That is because both the `command` method (app.rb:179) and the `exec` method (app.rb:247) use `app_path`, and when those are used together (such as in app.rb:29, in the 'run' method), it results in reaching too far down the path.  `exec` changes the directory to that of `app_path`, and then `command` tries to use the `app_path` again... but it uses it relative to `app_path` directory, reaching down twice.  Thus the command fails, and the build never occurs.

### The solution

`ember_path` changed to not use `app_path`.  In order to preserve the `executable?` check, I had to do some slightly non-ideal code.  Any suggestions on how to clean it up would be appreciated.

### Caveats

For larger apps, the first load after `rails s` results in the following errors:

```
 GET http://org.lvh.me:3000/javascripts/enterprise/vendor.js 
org.lvh.me/:62 GET http://org.lvh.me:3000/javascripts/enterprise/enterprise.js 404 (Not Found)
```
(the details will be different for each app, but the form should be the same)

Reloading the page makes the error go away, and it does not reoccur until you restart rails.  Smaller apps load without issue.  I am not sure whether this issue was previously existing.