### PR TITLE
Cleanup Rake Tasks

### DIFF
--- a/lib/ember-cli/helpers.rb
+++ b/lib/ember-cli/helpers.rb
@@ -37,15 +37,5 @@ module EmberCLI
       config = Rails.configuration
       config.respond_to?(key) ? config.public_send(key) : default
     end
-
-    def override_assets_precompile_task!
-      Rake.application.instance_eval do
-        @tasks["assets:precompile:original"] = @tasks.delete("assets:precompile")
-        dependencies = ["ember-cli:install_dependencies", "ember-cli:compile"]
-        Rake::Task.define_task "assets:precompile", [:assets, :precompile] => dependencies do
-          Rake::Task["assets:precompile:original"].execute
-        end
-      end
-    end
   end
 end

--- a/lib/ember-cli/railtie.rb
+++ b/lib/ember-cli/railtie.rb
@@ -15,9 +15,7 @@ module EmberCLI
     end
 
     rake_tasks do
-      require "sprockets/rails/task"
       load "tasks/ember-cli.rake"
-      Helpers.override_assets_precompile_task!
     end
   end
 end

--- a/lib/tasks/ember-cli.rake
+++ b/lib/tasks/ember-cli.rake
@@ -1,6 +1,6 @@
 namespace "ember-cli" do
   desc "Runs `ember build` for each App"
-  task compile: :environment do
+  task compile: :install_dependencies do
     EmberCLI.compile!
   end
 
@@ -14,3 +14,5 @@ namespace "ember-cli" do
     EmberCLI.install_dependencies!
   end
 end
+
+task "assets:precompile" => "ember-cli:compile"


### PR DESCRIPTION
* We don't need to require the sprockets tasks
* `override_assets_precompile_task` is an overcomplication of `task foo:
 :bar`
* We should make `ember-cli:compile` depend on
 `ember-cli:install_dependencies`
 * Worst case scenario, the `npm install` is a no-op