### PR TITLE
Support Gemfile in ember-cli application

### DIFF
--- a/lib/ember-cli/app.rb
+++ b/lib/ember-cli/app.rb
@@ -20,6 +20,7 @@ module EmberCLI
     end
 
     def install_dependencies
+      exec "bundle install" if gemfile_path.exist?
       exec "#{npm_path} install"
     end
 
@@ -241,7 +242,12 @@ module EmberCLI
       ENV.clone.tap do |vars|
         vars.store "DISABLE_FINGERPRINTING", "true"
         vars.store "EXCLUDE_EMBER_ASSETS", excluded_ember_deps
+        vars.store "BUNDLE_GEMFILE", gemfile_path
       end
+    end
+
+    def gemfile_path
+      app_path.join('Gemfile')
     end
 
     def exec(cmd, options={})


### PR DESCRIPTION
Some EmberCLI addons require gems like compass or susy to be installed.
There is no need to have these gems in the rails project's Gemfile.
This pull request adds the support for Gemfile in the ember-cli
application's directory.

Tested with:

  - rvm 1.26.10
  - ruby 2.1.3
  - rubygems 2.4.5

Caveats:
  - the ruby version in both ember-cli and rails applications must be
  identical