### PR TITLE
Serve EmberCLI tests as mountable engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,28 @@ could render your app at the `/` route with the following view:
 
 Your Ember application will now be served at the `/` route.
 
+## Ember Test Suite
+
+To run an Ember app's tests in a browser, mount the `EmberCLI::Engine`:
+
+```ruby
+# config/routes.rb
+
+Rails.application.routes.draw do
+  unless Rails.env.production?
+    mount EmberCLI::Rails => 'tests'
+  end
+
+  root 'application#index'
+end
+```
+
+Ember tests are served based on the route you mount the Engine on (in this
+example, `/tests`) and the name of the Ember app.
+
+For example, to view tests in `app/frontend`,
+visit `http://localhost:3000/tests/frontend`.
+
 ## Enabling LiveReload
 
 In order to get LiveReload up and running with EmberCLI Rails, you can install

--- a/app/controllers/ember_tests_controller.rb
+++ b/app/controllers/ember_tests_controller.rb
@@ -1,0 +1,27 @@
+class EmberTestsController < ActionController::Base
+  def index
+    render text: test_html_with_corrected_asset_urls, layout: false
+  end
+
+  private
+
+  def test_html_with_corrected_asset_urls
+    test_html.gsub(%r{assets/}i, "assets/#{app_name}/")
+  end
+
+  def test_html
+    tests_index_path.read
+  end
+
+  def tests_index_path
+    app.tests_path.join("index.html")
+  end
+
+  def app
+    EmberCLI.get_app(app_name)
+  end
+
+  def app_name
+    params[:app]
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,0 +1,3 @@
+EmberCLI::Engine.routes.draw do
+  get ":app" => "ember_tests#index", format: false, as: false
+end

--- a/lib/ember-cli-rails.rb
+++ b/lib/ember-cli-rails.rb
@@ -1,4 +1,4 @@
-require "ember-cli/railtie" if defined?(Rails)
+require "ember-cli/engine" if defined?(Rails)
 
 module EmberCLI
   extend self
@@ -15,6 +15,10 @@ module EmberCLI
 
   def configuration
     Configuration.instance
+  end
+
+  def get_app(name)
+    configuration.apps[name]
   end
 
   def prepare!

--- a/lib/ember-cli/app.rb
+++ b/lib/ember-cli/app.rb
@@ -13,6 +13,10 @@ module EmberCLI
       @name, @options = name.to_s, options
     end
 
+    def tests_path
+      dist_path.join("tests")
+    end
+
     def compile
       prepare
       silence_build { exec command }

--- a/lib/ember-cli/engine.rb
+++ b/lib/ember-cli/engine.rb
@@ -1,5 +1,5 @@
 module EmberCLI
-  class Railtie < Rails::Railtie
+  class Engine < Rails::Engine
     initializer "ember-cli-rails.view_helpers" do
       ActionView::Base.send :include, ViewHelpers
     end


### PR DESCRIPTION
Closes #18

Expose EmberCLI test suite through Rails