### PR TITLE
Add app/**/* and config/**/* to gemspec

### DIFF
--- a/ember-cli-rails.gemspec
+++ b/ember-cli-rails.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |spec|
   spec.summary  = "Integration between Ember CLI and Rails"
   spec.homepage = "https://github.com/rwz/ember-cli-rails"
   spec.license  = "MIT"
-  spec.files    = Dir["README.md", "CHANGELOG.md", "LICENSE.txt", "lib/**/*"]
+  spec.files    = Dir["README.md", "CHANGELOG.md", "LICENSE.txt", "lib/**/*", "app/**/*", "config/**/*"]
 
   spec.required_ruby_version = ">= 1.9.3"
 


### PR DESCRIPTION
When installing latest release v0.1.7 from ruby gems, files from those two directories are missing, thus mounting Ember tests does not work.