### PR TITLE
Add Support for Rails 3.1

### DIFF
--- a/ember-cli-rails.gemspec
+++ b/ember-cli-rails.gemspec
@@ -12,6 +12,6 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 1.9.3"
 
-  spec.add_dependency "railties",        "~> 4.0"
-  spec.add_dependency "sprockets-rails", "~> 2.0"
+  spec.add_dependency "railties", ">= 3.1", "< 5"
+  spec.add_dependency "sprockets", ">= 2.0"
 end

--- a/lib/ember-cli/engine.rb
+++ b/lib/ember-cli/engine.rb
@@ -5,8 +5,10 @@ module EmberCLI
     end
 
     initializer "ember-cli-rails.inflector" do
-      ActiveSupport::Inflector.inflections :en do |inflect|
-        inflect.acronym "CLI"
+      if Rails.version > "3.2"
+        ActiveSupport::Inflector.inflections :en do |inflect|
+          inflect.acronym "CLI"
+        end
       end
     end
 


### PR DESCRIPTION
Add Support for Rails 3.1

* reduce Railties version
* only inflect on `CLI` acronym if that API is available