### PR TITLE
Use Rails' configured asset prefix in tests

### DIFF
--- a/app/controllers/ember_tests_controller.rb
+++ b/app/controllers/ember_tests_controller.rb
@@ -6,7 +6,7 @@ class EmberTestsController < ActionController::Base
   private
 
   def test_html_with_corrected_asset_urls
-    test_html.gsub(%r{assets/}i, "assets/#{app_name}/")
+    test_html.gsub(%r{assets/}i, "#{asset_prefix}/#{app_name}/")
   end
 
   def test_html
@@ -23,5 +23,9 @@ class EmberTestsController < ActionController::Base
 
   def app_name
     params.fetch(:app_name)
+  end
+
+  def asset_prefix
+    Rails.configuration.assets.prefix
   end
 end


### PR DESCRIPTION
Don't assume assets are served from `/assets`