### PR TITLE
Remove rake_tasks block in engine

### DIFF
--- a/lib/ember-cli/engine.rb
+++ b/lib/ember-cli/engine.rb
@@ -15,9 +15,5 @@ module EmberCLI
     initializer "ember-cli-rails.enable" do
       EmberCLI.enable! unless ENV["SKIP_EMBER"]
     end
-
-    rake_tasks do
-      load "tasks/ember-cli.rake"
-    end
   end
 end


### PR DESCRIPTION
When the `rake_tasks` block is present and loading tasks it causes the
tasks to be loaded twice and runs them twice each time they are called.

Since ember-cli-rails uses an engine instead of a Railtie, it will load tasks for us: https://github.com/rails/rails/blob/4e0ec961e1f81ef672e2728b8650e4358962962f/railties/lib/rails/engine/configuration.rb#L52
https://github.com/rails/rails/blob/4e0ec961e1f81ef672e2728b8650e4358962962f/railties/lib/rails/engine.rb#L32