### PR TITLE
skipping inflections for Rails 3.2.x versions too

### DIFF
--- a/lib/ember-cli/engine.rb
+++ b/lib/ember-cli/engine.rb
@@ -5,7 +5,7 @@ module EmberCLI
     end
 
     initializer "ember-cli-rails.inflector" do
-      if Rails.version > "3.2"
+      if Rails.version > "3.2.x"
         ActiveSupport::Inflector.inflections :en do |inflect|
           inflect.acronym "CLI"
         end


### PR DESCRIPTION
I was running Rails version 3.2.18 and still getting the inflector error, so just wanted to skip it for 3.2.x