### PR TITLE
guard-livereload issue due to symlinked dirs

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ init` and then add the following to your `Guardfile`.
 ```ruby
 guard "livereload" do
   # ...
-  watch %r{app/<your-appname>/app/\w+/.+\.(js|hbs|html|css|<other-extensions>)}
+  watch %r{your-appname/app/\w+/.+\.(js|hbs|html|css|<other-extensions>)}
   # ...
 end
 ```
@@ -152,6 +152,19 @@ This tells Guard to watch your EmberCLI app for any changes to the JavaScript,
 Handlebars, HTML, or CSS files within `app` path. Take note that other
 extensions can be added to the line (such as `coffee` for CoffeeScript) to
 watch them for changes as well.
+
+*NOTE:* EmberCLI creates symlinks in `your-appname/tmp` directory, which cannot
+ be handled properly by Guard. This might lead to performance issues on some
+ platforms (most notably on OSX), as well as warnings being printed by latest
+ versions of Guard. As a work-around, one might use
+ [`directories`](https://github.com/guard/guard/wiki/Guardfile-DSL---Configuring-Guard#directories)
+ option, explicitly specifying directories to watch, e.g. adding the following
+ to the `Guardfile`.
+
+```ruby
+# also add directories that need to be watched by other guard plugins
+directories %w(app config lib spec your-appname/app)
+```
 
 ## Heroku
 


### PR DESCRIPTION
When using guard-livereload, I noticed performance issues on OSX (100% CPU usage, livereload working unreliably). After upgrading to latest `guard` and `guard-livereload` gems, I noticed warnings related to [duplicated directory errors](https://github.com/guard/listen/wiki/Duplicate-directory-errors). This was probably the underlying cause of performance issues in the first place.

I added a note to the README.md, including the workaround by explicitly specifying directories to watch.