### PR TITLE
Fix inflections with Rails 3.2

### DIFF
--- a/lib/ember-cli/engine.rb
+++ b/lib/ember-cli/engine.rb
@@ -5,8 +5,12 @@ module EmberCLI
     end
 
     initializer "ember-cli-rails.inflector" do
-      if Rails.version > "3.2"
+      if Rails.version > "4"
         ActiveSupport::Inflector.inflections :en do |inflect|
+          inflect.acronym "CLI"
+        end
+      elsif Rails.version > "3.2"
+        ActiveSupport::Inflector.inflections do |inflect|
           inflect.acronym "CLI"
         end
       end


### PR DESCRIPTION
Only Rails 4 supports i18n of inflections, but Rails 3.2 will still hang out with the acronym.

Rails 3.2: https://github.com/rails/rails/blob/3-2-stable/activesupport/lib/active_support/inflector/inflections.rb#L166

Rails 4: https://github.com/rails/rails/blob/4-0-stable/activesupport/lib/active_support/inflector/inflections.rb#L203