### PR TITLE
Don't Compile Assets if `SKIP_EMBER` set

### DIFF
--- a/lib/ember-cli-rails.rb
+++ b/lib/ember-cli-rails.rb
@@ -21,6 +21,10 @@ module EmberCLI
     configuration.apps[name]
   end
 
+  def skip?
+    ENV["SKIP_EMBER"]
+  end
+
   def prepare!
     @prepared ||= begin
       Rails.configuration.assets.paths << root.join("assets").to_s

--- a/lib/ember-cli/engine.rb
+++ b/lib/ember-cli/engine.rb
@@ -11,7 +11,7 @@ module EmberCLI
     end
 
     initializer "ember-cli-rails.enable" do
-      EmberCLI.enable! unless ENV["SKIP_EMBER"]
+      EmberCLI.enable! unless EmberCLI.skip?
     end
   end
 end

--- a/lib/tasks/ember-cli.rake
+++ b/lib/tasks/ember-cli.rake
@@ -15,4 +15,4 @@ namespace "ember-cli" do
   end
 end
 
-task "assets:precompile" => "ember-cli:compile"
+task "assets:precompile" => "ember-cli:compile" unless EmberCLI.skip?


### PR DESCRIPTION
Allows for co-located Rails / Ember apps to still utilize
`ember-cli-deploy`