### PR TITLE
Version 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+0.2.0
+-----
+
+* Rename rake namespace from ember-cli to ember [commit](https://github.com/rwz/ember-cli-rails/commit/3f5463835f05d21a34b5f8a9dfeb482b0501d8d4)
+* Allow helpers to take optons for ember assets [commit](https://github.com/rwz/ember-cli-rails/commit/335d117a5bf4d3520730c9c421a25aee5274c2b3)
+* Make EmberCLI.skip? predicate return boolean [commit](https://github.com/rwz/ember-cli-rails/commit/6f7cd58010aaf584e0810c44568008654bd1a764)
+* Introduce EmberCLI.env and ember\_cli\_rails\_mode config option [commit](https://github.com/rwz/ember-cli-rails/commit/4ff9ea1a1a152bee9f909e4379f6f469650891b5)
+* Rename EmberCLI.get\_app to .app and add .[] alias [commit](https://github.com/rwz/ember-cli-rails/commit/71b4c5cc97d9a410e2ef7acc536994e5d71175c6)
+
 0.1.13
 ------
 

--- a/app/controllers/ember_tests_controller.rb
+++ b/app/controllers/ember_tests_controller.rb
@@ -18,7 +18,7 @@ class EmberTestsController < ActionController::Base
   end
 
   def app
-    EmberCLI.get_app(app_name)
+    EmberCLI[app_name]
   end
 
   def app_name

--- a/app/helpers/ember_cli_rails_helper.rb
+++ b/app/helpers/ember_cli_rails_helper.rb
@@ -1,9 +1,9 @@
 module EmberCLIRailsHelper
-  def include_ember_script_tags(name)
-    javascript_include_tag *EmberCLI[name].exposed_js_assets
+  def include_ember_script_tags(name, options={})
+    javascript_include_tag *EmberCLI[name].exposed_js_assets, options
   end
 
-  def include_ember_stylesheet_tags(name)
-    stylesheet_link_tag *EmberCLI[name].exposed_css_assets
+  def include_ember_stylesheet_tags(name, options={})
+    stylesheet_link_tag *EmberCLI[name].exposed_css_assets, options
   end
 end

--- a/app/helpers/ember_cli_rails_helper.rb
+++ b/app/helpers/ember_cli_rails_helper.rb
@@ -1,11 +1,9 @@
 module EmberCLIRailsHelper
-  def include_ember_script_tags(app_name)
-    app = EmberCLI.configuration.apps.fetch(app_name)
-    javascript_include_tag *app.exposed_js_assets
+  def include_ember_script_tags(name)
+    javascript_include_tag *EmberCLI[name].exposed_js_assets
   end
 
-  def include_ember_stylesheet_tags(app_name)
-    app = EmberCLI.configuration.apps.fetch(app_name)
-    stylesheet_link_tag *app.exposed_css_assets
+  def include_ember_stylesheet_tags(name)
+    stylesheet_link_tag *EmberCLI[name].exposed_css_assets
   end
 end

--- a/lib/ember-cli-rails.rb
+++ b/lib/ember-cli-rails.rb
@@ -39,10 +39,7 @@ module EmberCLI
 
   def enable!
     prepare!
-
-    if Helpers.use_middleware?
-      Rails.configuration.middleware.use Middleware
-    end
+    append_middleware unless env.production?
   end
 
   def install_dependencies!
@@ -77,6 +74,10 @@ module EmberCLI
     @root ||= Rails.root.join("tmp", "ember-cli-#{uid}")
   end
 
+  def env
+    @env ||= Helpers.current_environment.inquiry
+  end
+
   delegate :apps, to: :configuration
 
   private
@@ -91,5 +92,9 @@ module EmberCLI
 
   def each_app
     apps.each{ |name, app| yield app }
+  end
+
+  def append_middleware
+    Rails.configuration.middleware.use Middleware
   end
 end

--- a/lib/ember-cli-rails.rb
+++ b/lib/ember-cli-rails.rb
@@ -7,6 +7,7 @@ module EmberCLI
   autoload :Configuration, "ember-cli/configuration"
   autoload :Helpers,       "ember-cli/helpers"
   autoload :Middleware,    "ember-cli/middleware"
+  autoload :PathSet,       "ember-cli/path_set"
 
   def configure
     yield configuration

--- a/lib/ember-cli-rails.rb
+++ b/lib/ember-cli-rails.rb
@@ -26,7 +26,7 @@ module EmberCLI
   alias_method :[], :app
 
   def skip?
-    ENV["SKIP_EMBER"]
+    ENV["SKIP_EMBER"].present?
   end
 
   def prepare!

--- a/lib/ember-cli-rails.rb
+++ b/lib/ember-cli-rails.rb
@@ -17,9 +17,13 @@ module EmberCLI
     Configuration.instance
   end
 
-  def get_app(name)
-    configuration.apps[name]
+  def app(name)
+    apps.fetch(name) do
+      fail KeyError, "#{name.inspect} app is not defined"
+    end
   end
+
+  alias_method :[], :app
 
   def skip?
     ENV["SKIP_EMBER"]
@@ -73,6 +77,8 @@ module EmberCLI
     @root ||= Rails.root.join("tmp", "ember-cli-#{uid}")
   end
 
+  delegate :apps, to: :configuration
+
   private
 
   def uid
@@ -84,6 +90,6 @@ module EmberCLI
   end
 
   def each_app
-    configuration.apps.each{ |name, app| yield app }
+    apps.each{ |name, app| yield app }
   end
 end

--- a/lib/ember-cli/app.rb
+++ b/lib/ember-cli/app.rb
@@ -100,14 +100,13 @@ module EmberCLI
 
     private
 
-    delegate :match_version?, :non_production?, to: Helpers
     def supported_path_method(original)
       path_method = original.to_s[/\A(.+)_path\z/, 1]
       path_method if path_method && paths.respond_to?(path_method)
     end
 
     def silence_build(&block)
-      if ENV.fetch("EMBER_CLI_RAILS_VERBOSE"){ !non_production? }
+      if ENV.fetch("EMBER_CLI_RAILS_VERBOSE"){ EmberCLI.env.production? }
         yield
       else
         silence_stream STDOUT, &block
@@ -151,7 +150,7 @@ module EmberCLI
     def check_ember_cli_version!
       version = dev_dependencies.fetch("ember-cli").split(?-).first
 
-      unless match_version?(version, EMBER_CLI_VERSION)
+      unless Helpers.match_version?(version, EMBER_CLI_VERSION)
         fail <<-MSG.strip_heredoc
           EmberCLI Rails require ember-cli NPM package version to be
           #{EMBER_CLI_VERSION} to work properly. From within your EmberCLI directory
@@ -202,7 +201,7 @@ module EmberCLI
     end
 
     def environment
-      non_production?? "development" : "production"
+      EmberCLI.env.production?? "production" : "development"
     end
 
     def package_json

--- a/lib/ember-cli/app.rb
+++ b/lib/ember-cli/app.rb
@@ -110,7 +110,7 @@ module EmberCLI
       if ENV.fetch("EMBER_CLI_RAILS_VERBOSE"){ !non_production? }
         yield
       else
-        silence_stream(STDOUT, &block)
+        silence_stream STDOUT, &block
       end
     end
 

--- a/lib/ember-cli/helpers.rb
+++ b/lib/ember-cli/helpers.rb
@@ -24,21 +24,25 @@ module EmberCLI
       nil
     end
 
-    def non_production?
-      !Rails.env.production? && rails_config_for(:consider_all_requests_local)
+    def current_environment
+      rails_config_for(:ember_cli_rails_mode){ default_environment }.to_s
     end
 
-    def use_middleware?
-      rails_config_for(:use_ember_middleware, non_production?)
+    private
+
+    def default_environment
+      if Rails.env.test?
+        "test"
+      elsif Rails.env.production? || !rails_config_for(:consider_all_requests_local)
+        "production"
+      else
+        "development"
+      end
     end
 
-    def use_live_recompilation?
-      rails_config_for(:use_ember_live_recompilation, Rails.env.development?)
-    end
-
-    def rails_config_for(key, default=false)
+    def rails_config_for(key)
       config = Rails.configuration
-      config.respond_to?(key) ? config.public_send(key) : default
+      config.respond_to?(key) ? config.public_send(key) : yield
     end
   end
 end

--- a/lib/ember-cli/middleware.rb
+++ b/lib/ember-cli/middleware.rb
@@ -19,7 +19,7 @@ module EmberCLI
 
     def enable_ember_cli
       @enabled ||= begin
-        if Helpers.use_live_recompilation?
+        if EmberCLI.env.development?
           EmberCLI.run!
         else
           EmberCLI.compile!

--- a/lib/ember-cli/path_set.rb
+++ b/lib/ember-cli/path_set.rb
@@ -1,0 +1,96 @@
+module EmberCLI
+  class PathSet
+    def self.define_path(name, &definition)
+      define_method name do
+        ivar = "@_#{name}_path"
+        if instance_variable_defined?(ivar)
+          instance_variable_get(ivar)
+        else
+          instance_exec(&definition).tap{ |value| instance_variable_set ivar, value }
+        end
+      end
+    end
+
+    def initialize(app)
+      @app = app
+    end
+
+    define_path :root do
+      path = app_options.fetch(:path){ default_root }
+      pathname = Pathname.new(path)
+      pathname.absolute?? pathname : Rails.root.join(path)
+    end
+
+    define_path :tmp do
+      root.join("tmp").tap(&:mkpath)
+    end
+
+    define_path :log do
+      Rails.root.join("log", "ember-#{app_name}.#{Rails.env}.log")
+    end
+
+    define_path :dist do
+      EmberCLI.root.join("apps", app_name).tap(&:mkpath)
+    end
+
+    define_path :assets do
+      EmberCLI.root.join("assets").tap(&:mkpath)
+    end
+
+    define_path :gemfile do
+      root.join("Gemfile")
+    end
+
+    define_path :tests do
+      dist.join("tests")
+    end
+
+    define_path :package_json_file do
+      root.join("package.json")
+    end
+
+    define_path :ember do
+      root.join("node_modules", ".bin", "ember").tap do |path|
+        fail <<-MSG.strip_heredoc unless path.executable?
+          No local ember executable found. You should run `npm install`
+          inside the #{app_name} app located at #{root}
+        MSG
+      end
+    end
+
+    define_path :lockfile do
+      tmp.join("build.lock")
+    end
+
+    define_path :build_error_file do
+      tmp.join("error.txt")
+    end
+
+    define_path :tee do
+      app_options.fetch(:tee_path){ configuration.tee_path }
+    end
+
+    define_path :npm do
+      app_options.fetch(:npm_path){ configuration.npm_path }
+    end
+
+    define_path :bundler do
+      app_options.fetch(:bundler_path){ configuration.bundler_path }
+    end
+
+    define_path :addon_package_json_file do
+      root.join("node_modules", "ember-cli-rails-addon", "package.json")
+    end
+
+    private
+
+    attr_reader :app
+
+    delegate :name, :options, to: :app, prefix: true
+    delegate :configuration, to: EmberCLI
+
+    def default_root
+      Rails.root.join(app_name)
+    end
+  end
+end

--- a/lib/ember-cli/version.rb
+++ b/lib/ember-cli/version.rb
@@ -1,3 +1,3 @@
 module EmberCLI
-  VERSION = "0.1.13".freeze
+  VERSION = "0.2.0".freeze
 end

--- a/lib/tasks/ember-cli.rake
+++ b/lib/tasks/ember-cli.rake
@@ -1,6 +1,6 @@
-namespace "ember-cli" do
+namespace :ember do
   desc "Runs `ember build` for each App"
-  task compile: :install_dependencies do
+  task compile: :install do
     EmberCLI.compile!
   end
 
@@ -10,9 +10,9 @@ namespace "ember-cli" do
   end
 
   desc "Installs each EmberCLI app's dependencies"
-  task install_dependencies: :environment do
+  task install: :environment do
     EmberCLI.install_dependencies!
   end
 end
 
-task "assets:precompile" => "ember-cli:compile" unless EmberCLI.skip?
+task "assets:precompile" => "ember:compile" unless EmberCLI.skip?


### PR DESCRIPTION
I've rewrote some stuff and changed the way configuration works. Now everything depends on `EmberCLI.env` method that works kind of like `Rails.env` does. It controls which mode kicks in when `EmberCLI.enable!` is called.

- test: compile on first request, do nothing afterwards
- development: run build server on first request
- production: do nothing

In each mode EmberCLI assets are added to the pipeline, so `rake assets:precompile` includes it.

User can manually override which mode should be used by specifying `config.ember_cli_rails_mode = <something>` in the environment file.

We're not at 1.0 yet, so it's OK to break backward compatibility between minor versions.

@rondale-sc @seanpdoyle could you guys review changes and maybe run your projects test against this branch?