### PR TITLE
Skip Middleware on `/api/` requests

### DIFF
--- a/lib/ember-cli/middleware.rb
+++ b/lib/ember-cli/middleware.rb
@@ -5,8 +5,10 @@ module EmberCLI
     end
 
     def call(env)
-      enable_ember_cli
-      EmberCLI.wait!
+      unless skip_middleware?
+        enable_ember_cli
+        EmberCLI.wait!
+      end
 
       if env["PATH_INFO"] == "/testem.js"
         [ 200, { "Content-Type" => "text/javascript" }, [""] ]
@@ -16,6 +18,10 @@ module EmberCLI
     end
 
     private
+
+    def skip_middleware?
+      %r{/api/}.match(env["REQUEST_URI"])
+    end
 
     def enable_ember_cli
       @enabled ||= begin


### PR DESCRIPTION
Closes https://github.com/rwz/ember-cli-rails/issues/139

Disabling middleware for API only tests keeps the feedback loop tight.
When test driving an API, this is ideal.

Ideally, this would be configurable. For now, this is a fairly sane
default.