### PR TITLE
BUILDPACK_URL deprecated, use buildpacks:set

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ In order to deploy EmberCLI Rails app to Heroku:
 First, enable Heroku Multi Buildpack by running the following command:
 
 ```sh
-heroku config:add BUILDPACK_URL=https://github.com/heroku/heroku-buildpack-multi
+heroku buildpacks:set https://github.com/heroku/heroku-buildpack-multi
 ```
 
 Next, specify which buildpacks to use by creating a `.buildpacks` file in the project root containing:


### PR DESCRIPTION
> Previously you could set a config var for BUILDPACK_URL, this value will still be used if set, though a buildpack value set through the CLI will take precedence. BUILDPACK_URL as a config var is now deprecated in favor of the buildpack value on the API and in the future will be migrated.

https://devcenter.heroku.com/articles/buildpacks#using-a-custom-buildpack