### PR TITLE
Add a watcher option

### DIFF
--- a/lib/ember-cli/app.rb
+++ b/lib/ember-cli/app.rb
@@ -126,6 +126,10 @@ module EmberCLI
       options.fetch(:build_timeout){ EmberCLI.configuration.build_timeout }
     end
 
+    def watcher
+      options.fetch(:watcher){ EmberCLI.configuration.watcher }
+    end
+
     def check_for_build_error!
       raise_build_error! if build_error?
     end
@@ -196,7 +200,12 @@ module EmberCLI
     end
 
     def command(options={})
-      watch = options[:watch] ? "--watch" : ""
+      watch = ""
+      if options[:watch]
+        watch = "--watch"
+        watch += " --watcher #{watcher}" if watcher
+      end
+
       "#{ember_path} build #{watch} --environment #{environment} --output-path #{dist_path} #{log_pipe}"
     end
 

--- a/lib/ember-cli/configuration.rb
+++ b/lib/ember-cli/configuration.rb
@@ -30,5 +30,6 @@ module EmberCLI
     end
 
     attr_writer :build_timeout
+    attr_accessor :watcher
   end
 end


### PR DESCRIPTION
We run our app inside of Vagrant which syncs files via NFS. Unfortunately the default watcher does not detect file system changes in this setup, so we need to fallback on polling. This PR is to add support for a watcher option to the build command.