### PR TITLE
Convert current environment variables into a hash before adding new variables

### DIFF
--- a/lib/ember-cli/app.rb
+++ b/lib/ember-cli/app.rb
@@ -240,11 +240,11 @@ module EmberCLI
     end
 
     def env_hash
-      ENV.clone.tap do |vars|
-        vars.store "RAILS_ENV", Rails.env
-        vars.store "DISABLE_FINGERPRINTING", "true"
-        vars.store "EXCLUDE_EMBER_ASSETS", excluded_ember_deps
-        vars.store "BUNDLE_GEMFILE", gemfile_path.to_s if gemfile_path.exist?
+      ENV.to_h.tap do |vars|
+        vars["RAILS_ENV"] = Rails.env
+        vars["DISABLE_FINGERPRINTING"] = "true"
+        vars["EXCLUDE_EMBER_ASSETS"] = excluded_ember_deps
+        vars["BUNDLE_GEMFILE"] = gemfile_path.to_s if gemfile_path.exist?
       end
     end
 


### PR DESCRIPTION
We had the `blank_slate` gem installed which threw odd errors on attempting to clone the ENV object, due to its monkey-patching methods into Object. If we instead just create a hash with a copy of the values from ENV with `to_h`, everything seems to run perfectly fine.