### PR TITLE
Allow `enable` proc to accept Rack `env`

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,15 +51,15 @@ end
 - path - the path, where your EmberCLI applications is located. The default
   value is the name of your app in the Rails root.
 
-- enable - a lambda that accepts each requests' path. The default value is a
-  lambda that returns `true`.
+- enable - a lambda that accepts each requests' path, and optionally the Rack
+  `env`.. The default value is a lambda that returns `true`.
 
 ```ruby
 EmberCLI.configure do |c|
   c.app :adminpanel # path is "<your-rails-root>/adminpanel"
   c.app :frontend,
     path: "/path/to/your/ember-cli-app/on/disk",
-    enable: -> path { path.starts_with?("/app/") }
+    enable: -> path, env { path.starts_with?("/app/") }
 end
 ```
 

--- a/lib/ember-cli-rails.rb
+++ b/lib/ember-cli-rails.rb
@@ -58,8 +58,8 @@ module EmberCLI
     each_app &:compile
   end
 
-  def process_path(path)
-    each_app{ |app| Runner.new(app, path).process }
+  def process_request(env)
+    each_app{ |app| Runner.new(app, env).process }
   end
 
   def root

--- a/lib/ember-cli/middleware.rb
+++ b/lib/ember-cli/middleware.rb
@@ -10,7 +10,7 @@ module EmberCLI
       if path == "/testem.js"
         [ 200, { "Content-Type" => "text/javascript" }, [""] ]
       else
-        EmberCLI.process_path path
+        EmberCLI.process_request env
         @app.call(env)
       end
     end

--- a/lib/ember-cli/runner.rb
+++ b/lib/ember-cli/runner.rb
@@ -2,10 +2,10 @@ module EmberCLI
   class Runner
     TRUE_PROC = ->(*){ true }
 
-    attr_reader :app, :path
+    attr_reader :app, :env
 
-    def initialize(app, path)
-      @app, @path = app, path
+    def initialize(app, env)
+      @app, @env = app, env
     end
 
     def process
@@ -22,9 +22,20 @@ module EmberCLI
 
     private
 
+    def path
+      env["PATH_INFO"].to_s
+    end
+
     def skip?
       invoker = app.options.fetch(:enable, TRUE_PROC)
-      !invoker.call(path)
+
+      if invoker.arity == 2
+        enabled = invoker.call(path, env)
+      else
+        enabled = invoker.call(path)
+      end
+
+      !enabled
     end
 
     def start_or_restart!


### PR DESCRIPTION
Some requests can be routed differently, depending on the HTTP verb.

For instance, in FormKeep, we display the Ember app for `GET /f/:token`,
but handle a Form submission via a `POST /f/:token`.